### PR TITLE
Only pin minimum versions of core requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp==3.6.2
-xmltodict==0.12.0
-yarl==1.4.2
+aiohttp>=3.6.2
+xmltodict>=0.12.0
+yarl>=1.4.2


### PR DESCRIPTION
closes #46 