### PR TITLE
Add DNS TTL caching to hostname lookup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp>=3.6.2
+cachetools>=4.0.0
 xmltodict>=0.12.0
 yarl>=1.4.2

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -57,7 +57,7 @@ class Client:
     ) -> Any:
         """Handle a request to a receiver."""
         host = self.host
-        if self.dns_lookup:
+        if self._dns_lookup:
             try:
                 host = self._dns_cache["ip_address"]
             except KeyError:

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -6,8 +6,8 @@ from xml.parsers.expat import ExpatError
 
 import aiohttp
 import async_timeout
-from cachetools import TTLCache
 import xmltodict
+from cachetools import TTLCache
 from yarl import URL
 
 from .__version__ import __version__

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -57,7 +57,7 @@ class Client:
             try:
                 host = self._dns_cache["ip_address"]
             except KeyError:
-                host = self.resolve_hostname(host)
+                host = await self.resolve_hostname(host)
                 self._dns_cache = {"ip_address": host};
 
         url = URL.build(

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -20,7 +20,7 @@ class Client:
 
     _close_session: bool
     _dns_lookup: bool
-    _dns_cache: TTLCache = TTLCache(maxsize=16, ttl=7200)
+    _dns_cache: TTLCache
     _session: aiohttp.client.ClientSession
 
     def __init__(
@@ -35,6 +35,7 @@ class Client:
         """Initialize connection with device."""
         self._session = session
         self._close_session = False
+        self._dns_cache = TTLCache(maxsize=16, ttl=7200)
         self._dns_lookup = is_ip_address(host)
 
         self.base_path = base_path

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -36,7 +36,7 @@ class Client:
         self._session = session
         self._close_session = False
         self._dns_cache = TTLCache(maxsize=16, ttl=7200)
-        self._dns_lookup = is_ip_address(host) === False
+        self._dns_lookup = is_ip_address(host) is False
 
         self.base_path = base_path
         self.host = host

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -58,7 +58,7 @@ class Client:
                 host = self._dns_cache["ip_address"]
             except KeyError:
                 host = await resolve_hostname(host)
-                self._dns_cache = {"ip_address": host};
+                self._dns_cache["ip_address"] = host;
 
         url = URL.build(
             scheme=self.scheme, host=host, port=self.port, path=self.base_path

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -57,7 +57,7 @@ class Client:
             try:
                 host = self._dns_cache["ip_address"]
             except KeyError:
-                host = await self.resolve_hostname(host)
+                host = await resolve_hostname(host)
                 self._dns_cache = {"ip_address": host};
 
         url = URL.build(

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -62,7 +62,7 @@ class Client:
                 host = self._dns_cache["ip_address"]
             except KeyError:
                 host = await resolve_hostname(host)
-                self._dns_cache["ip_address"] = host;
+                self._dns_cache["ip_address"] = host
 
         url = URL.build(
             scheme=self.scheme, host=host, port=self.port, path=self.base_path

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -36,7 +36,7 @@ class Client:
         self._session = session
         self._close_session = False
         self._dns_cache = TTLCache(maxsize=16, ttl=7200)
-        self._dns_lookup = is_ip_address(host)
+        self._dns_lookup = is_ip_address(host) === False
 
         self.base_path = base_path
         self.host = host
@@ -57,6 +57,7 @@ class Client:
     ) -> Any:
         """Handle a request to a receiver."""
         host = self.host
+
         if self._dns_lookup:
             try:
                 host = self._dns_cache["ip_address"]

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -57,7 +57,7 @@ class Client:
     ) -> Any:
         """Handle a request to a receiver."""
         host = self.host
-        if dns_lookup:
+        if self.dns_lookup:
             try:
                 host = self._dns_cache["ip_address"]
             except KeyError:

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -61,7 +61,7 @@ class Client:
             try:
                 host = self._dns_cache["ip_address"]
             except KeyError:
-                host = await resolve_hostname(host)
+                host = await resolve_hostname(self.host)
                 self._dns_cache["ip_address"] = host
 
         url = URL.build(

--- a/rokuecp/client.py
+++ b/rokuecp/client.py
@@ -56,7 +56,7 @@ class Client:
         if not is_ip_address(host):
             try:
                 host = self._dns_cache["ip_address"]
-            catch KeyError:
+            except KeyError:
                 host = self.resolve_hostname(host)
                 self._dns_cache = {"ip_address": host};
 


### PR DESCRIPTION
will cache dns lookups for 2 hours compared to forever before.