### PR TITLE
Add new Mime types for ubuntu-22.04 and MacOS

### DIFF
--- a/src/rokuecp/helpers.py
+++ b/src/rokuecp/helpers.py
@@ -12,13 +12,17 @@ from .resolver import ThreadedResolver
 
 MIME_TO_STREAM_FORMAT = {
     "application/dash+xml": "dash",
-    "application/x-mpegURL": "hls",
+    "application/x-mpegurl": "hls",
     "application/vnd.apple.mpegurl": "hls",
     "audio/mpeg": "mp3",
+    "audio/mp4": "m4a",
+    "audio/mp4a-latm": "m4a",
+    "audio/x-matroska": "mka",
     "audio/x-ms-wma": "wma",
     "video/mp4": "mp4",
     "video/quicktime": "mp4",
     "video/x-matroska": "mkv",
+    "video/x-m4v": "mp4",
 }
 
 
@@ -60,10 +64,7 @@ def guess_stream_format(  # pylint: disable=too-many-return-statements
     if mime_type is None:
         return None
 
-    if mime_type not in MIME_TO_STREAM_FORMAT:
-        return None
-
-    return MIME_TO_STREAM_FORMAT[mime_type]
+    return MIME_TO_STREAM_FORMAT.get(mime_type.casefold())
 
 
 def is_ip_address(host: str) -> bool:


### PR DESCRIPTION
Ubuntu 22.04 changed the Mime types a bit which causes Home Assistant tests to fail when updating our CI runner.

| Type | Ubuntu 20.04 | Ubuntu 22.04 | MacOS |
| ----- | -------------- | -------------- | ------- |
| `m4a` | `audio/mpeg` | `audio/mp4` | `audio/mp4a-latm` |
| `mka` | | | `audio/x-matroska` |
| `m3u8` | `x-mpegURL` | `application/vnd.apple.mpegurl` | `x-mpegurl` |
| `m4v` | | `video/mp4` | `video/x-m4v` |

Blocks https://github.com/home-assistant/core/pull/88420