### PR TITLE
Recognize and record wake-on-wlan in Device.info

### DIFF
--- a/src/rokuecp/models.py
+++ b/src/rokuecp/models.py
@@ -74,6 +74,7 @@ class Info:
     supports_airplay: bool | None = None
     supports_find_remote: bool | None = None
     supports_private_listening: bool | None = None
+    supports_wake_on_wlan: bool | None = None
     headphones_connected: bool | None = None
 
     @staticmethod
@@ -114,6 +115,7 @@ class Info:
             supports_airplay=airplay,
             supports_find_remote=find_remote,
             supports_private_listening=private_listening,
+            supports_wake_on_wlan=data.get("supports-wake-on-wlan", "false") == "true",
             headphones_connected=data.get("headphones-connected", "false") == "true",
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -165,6 +165,7 @@ def test_info() -> None:
     assert not info.supports_airplay
     assert not info.supports_find_remote
     assert not info.supports_private_listening
+    assert not info.supports_wake_on_wlan
     assert not info.headphones_connected
     assert info.version == "7.5.0"
 
@@ -189,6 +190,7 @@ def test_info_stick_3500x() -> None:
     assert not info.supports_airplay
     assert info.supports_find_remote
     assert not info.supports_private_listening
+    assert not info.supports_wake_on_wlan
     assert not info.headphones_connected
     assert info.version == "10.0.0"
 
@@ -213,6 +215,7 @@ def test_info_tv_7820x() -> None:
     assert info.supports_airplay
     assert info.supports_find_remote
     assert info.supports_private_listening
+    assert info.supports_wake_on_wlan
     assert not info.headphones_connected
     assert info.version == "9.2.0"
 
@@ -237,6 +240,7 @@ def test_info_tv_d803x() -> None:
     assert info.supports_airplay
     assert not info.supports_find_remote
     assert info.supports_private_listening
+    assert info.supports_wake_on_wlan
     assert not info.headphones_connected
     assert info.version == "10.0.0"
 


### PR DESCRIPTION
This will allow users of this library to detect whether a Roku device is able to use Wake on Lan magic packets to power on. The application can then choose to send this magic packet to the retained MAC address of this device to wake it, even from deep sleep where it cannot be woken up through keypress/poweron.