### PR TITLE
Fix typing

### DIFF
--- a/src/rokuecp/models.py
+++ b/src/rokuecp/models.py
@@ -156,7 +156,7 @@ class Channel:
     signal_strength: int | None = None
 
     @staticmethod
-    def from_dict(data: dict) -> Channel:
+    def from_dict(data: dict[str, Any]) -> Channel:
         """Return Channel object from Roku response.
 
         Args:
@@ -197,7 +197,7 @@ class MediaState:
     at: datetime = datetime.utcnow()  # noqa: DTZ003, RUF009  # pylint: disable=C0103
 
     @staticmethod
-    def from_dict(data: dict) -> MediaState | None:
+    def from_dict(data: dict[str, Any]) -> MediaState | None:
         """Return MediaStste object from Roku response.
 
         Args:

--- a/src/rokuecp/rokuecp.py
+++ b/src/rokuecp/rokuecp.py
@@ -147,6 +147,7 @@ class Roku:
 
         content_type = response.headers.get("Content-Type", "")
 
+        content: str | bytes
         if (response.status // 100) in [4, 5]:
             content = await response.read()
             response.close()
@@ -221,7 +222,7 @@ class Roku:
         if self._device is None:
             full_update = True
 
-        updates: dict = {}
+        updates: dict[str, Any] = {}
         updates["info"] = None
         updates["available"] = True
         updates["standby"] = False
@@ -386,7 +387,7 @@ class Roku:
         if not isinstance(res, dict) or "active-app" not in res:
             raise RokuError("Roku device returned a malformed result (active-app)")
 
-        return res["active-app"]
+        return res["active-app"]  # type: ignore[no-any-return]
 
     async def _get_apps(self) -> list[dict[str, Any]]:
         """Retrieve apps for updates.
@@ -407,7 +408,7 @@ class Roku:
         if isinstance(res["apps"]["app"], dict):
             return [res["apps"]["app"]]
 
-        return res["apps"]["app"]
+        return res["apps"]["app"]  # type: ignore[no-any-return]
 
     async def _get_device_info(self) -> dict[str, Any]:
         """Retrieve device info for updates.
@@ -425,7 +426,7 @@ class Roku:
         if not isinstance(res, dict) or "device-info" not in res:
             raise RokuError("Roku device returned a malformed result (device-info)")
 
-        return res["device-info"]
+        return res["device-info"]  # type: ignore[no-any-return]
 
     async def _get_media_state(self) -> dict[str, Any]:
         """Retrieve media state for updates.
@@ -443,7 +444,7 @@ class Roku:
         if not isinstance(res, dict) or "player" not in res:
             raise RokuError("Roku device returned a malformed result (player)")
 
-        return res["player"]
+        return res["player"]  # type: ignore[no-any-return]
 
     async def _get_tv_active_channel(self) -> dict[str, Any]:
         """Retrieve active TV channel for updates.
@@ -463,7 +464,7 @@ class Roku:
                 "Roku device returned a malformed result (tv-active-channel)",
             )
 
-        return res["tv-channel"]["channel"]
+        return res["tv-channel"]["channel"]  # type: ignore[no-any-return]
 
     async def _get_tv_channels(self) -> list[dict[str, Any]]:
         """Retrieve TV channels for updates.
@@ -487,7 +488,7 @@ class Roku:
         if isinstance(res["tv-channels"]["channel"], dict):
             return [res["tv-channels"]["channel"]]
 
-        return res["tv-channels"]["channel"]
+        return res["tv-channels"]["channel"]  # type: ignore[no-any-return]
 
     def get_dns_state(self) -> dict[str, Any]:
         """Retrieve DNS resolution state.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,14 @@
 """Tests for Roku."""
+from __future__ import annotations
+
 import os
 import socket
 
 
-def fake_addrinfo_results(hosts: list, family: int = socket.AF_INET) -> list:
+def fake_addrinfo_results(
+    hosts: list[str],
+    family: int = socket.AF_INET,
+) -> list[tuple[int, None, None, None, list[str | int]]]:
     """Resolve hostname for mocked testing."""
     return [(family, None, None, None, [h, 0]) for h in hosts]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import datetime, timedelta
 from socket import gaierror
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from aiohttp import ClientError, ClientResponse, ClientSession
@@ -184,11 +184,12 @@ async def test_timeout(aresponses: ResponsesMockServer) -> None:
 async def test_client_error() -> None:
     """Test HTTP client error."""
     async with ClientSession() as session:
-        session.request = AsyncMock(side_effect=ClientError)
+        with patch.object(session, "request") as mock:
+            mock.side_effect = ClientError
 
-        client = Roku(HOST, session=session)
-        with pytest.raises(RokuConnectionError):
-            assert await client._request("client/error", method="ABC")
+            client = Roku(HOST, session=session)
+            with pytest.raises(RokuConnectionError):
+                assert await client._request("client/error", method="ABC")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fix current typing issues. For the `Returning Any from function declared to return ...` cases, it's probably best to add a `type: ignore`. The alternative would be a `cast` but that doesn't provide any more type safety. 