### PR TITLE
Fix handling of special character sent via literal

### DIFF
--- a/src/rokuecp/rokuecp.py
+++ b/src/rokuecp/rokuecp.py
@@ -345,7 +345,7 @@ class Roku:
         """
         for char in text:
             encoded = quote_plus(char)
-            await self._request(f"keypress/Lit_{encoded}", method="POST")
+            await self._request(f"keypress/Lit_{encoded}", method="POST", encoded=True)
 
     async def remote(self, key: str) -> None:
         """Emulate pressing a key on the remote.

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -204,6 +204,13 @@ async def test_literal(aresponses: ResponsesMockServer) -> None:
 
     aresponses.add(
         MATCH_HOST,
+        "/keypress/Lit_%20",
+        "POST",
+        aresponses.Response(status=200),
+    )
+
+    aresponses.add(
+        MATCH_HOST,
         "/keypress/Lit_%40",
         "POST",
         aresponses.Response(status=200),
@@ -211,9 +218,9 @@ async def test_literal(aresponses: ResponsesMockServer) -> None:
 
     async with ClientSession() as session:
         roku = Roku(HOST, session=session)
-        await roku.literal("the@")
+        await roku.literal("the @")
 
-    aresponses.assert_called_in_order()
+    aresponses.assert_plan_strictly_followed()
 
 
 @pytest.mark.asyncio

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -213,6 +213,8 @@ async def test_literal(aresponses: ResponsesMockServer) -> None:
         roku = Roku(HOST, session=session)
         await roku.literal("the@")
 
+    aresponses.assert_called_in_order()
+
 
 @pytest.mark.asyncio
 async def test_remote(aresponses: ResponsesMockServer) -> None:

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -204,14 +204,14 @@ async def test_literal(aresponses: ResponsesMockServer) -> None:
 
     aresponses.add(
         MATCH_HOST,
-        "/keypress/Lit_%20",
+        "/keypress/Lit_+",
         "POST",
         aresponses.Response(status=200),
     )
 
     aresponses.add(
         MATCH_HOST,
-        "/keypress/Lit_%40",
+        "/keypress/Lit_@",
         "POST",
         aresponses.Response(status=200),
     )

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -202,9 +202,16 @@ async def test_literal(aresponses: ResponsesMockServer) -> None:
         aresponses.Response(status=200),
     )
 
+    aresponses.add(
+        MATCH_HOST,
+        "/keypress/Lit_%40",
+        "POST",
+        aresponses.Response(status=200),
+    )
+
     async with ClientSession() as session:
         roku = Roku(HOST, session=session)
-        await roku.literal("the")
+        await roku.literal("the@")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
ref https://github.com/home-assistant/core/issues/110511

```
Character: @

Does not work
curl -d '' http://192.168.107.214:8060/keypress/Lit_@

Does work
curl -d '' http://192.168.107.214:8060/keypress/Lit_%40
```