### PR TITLE
Add sleep to keypress whitelist

### DIFF
--- a/src/rokuecp/const.py
+++ b/src/rokuecp/const.py
@@ -23,6 +23,7 @@ VALID_REMOTE_KEYS = {
     "volume_down": "VolumeDown",
     "volume_up": "VolumeUp",
     "volume_mute": "VolumeMute",
+    "sleep": "Sleep",
     # For Roku TV while on TV tuner channel
     "channel_up": "ChannelUp",
     "channel_down": "ChannelDown",


### PR DESCRIPTION
Adding sleep command to keypress whitelist

This is in reference to Home Assistant Core Issue [#109060](https://github.com/home-assistant/core/issues/109060)